### PR TITLE
Correcting path for "proguard-android.txt" file in latest Android Cordova

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,11 @@ android {
   buildTypes {
     debug {
       minifyEnabled true
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'assets/www/proguard-custom.txt'
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'src/main/assets/www/proguard-custom.txt'
     }
     release {
       minifyEnabled true
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'assets/www/proguard-custom.txt'
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'src/main/assets/www/proguard-custom.txt'
     }
   }
 }


### PR DESCRIPTION
Correcting the path for `proguard-android.txt` in `build.gradle` file.
I have tested out latest changes from [forked repo](https://github.com/SujitSingh/cordova-plugin-proguard). App works perfectly and the `classes.dex` file contains renamed class files.

closes #2 