### PR TITLE
billing proguard option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[*.{json,yml}]
+indent_style = space
+indent_size = 2
+

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+    "node": true,
+    "browser": true,
+    "undef": true,
+    "esversion": 6
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+NODE_MODULES?=node_modules
+help:
+	@echo ""
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "available targets:"
+	@echo "    tests ............. Run all tests."
+	@echo "    test-js ........... Test javascript files for errors."
+	@echo "    test-install ...... Test plugin installation Android."
+	@echo ""
+	@echo ""
+
+test-js: jshint
+
+jshint: check-jshint
+	@echo "- JSHint"
+	@${NODE_MODULES}/.bin/jshint --config .jshintrc scripts/*.js
+	@echo "  Done"
+	@echo ""
+
+test-install:
+	@./test/run.sh com.graybax.progplugintest progplugintest
+
+tests: jshint test-install
+	@echo 'ok'
+
+check-jshint:
+	@test -e "${NODE_MODULES}/.bin/jshint" || ( echo "${NODE_MODULES} not found."; echo 'Please install dependencies: npm install'; exit 1 )
+
+clean:
+	@find . -name '*~' -exec rm '{}' ';'

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ You can read more about it on [ProGuard official website](https://www.guardsquar
 
 You can also to check out some [Android ProGuard snippets](https://github.com/krschultz/android-proguard-snippets)
 
-_**Please note**_: you should remove and re-add Android platform after changing `plugins/cordova-plugin-proguard/proguard-custom.txt`
+If you want to add rules to this `proguard-custom.txt`, please create your own `proguard-custom.txt` and add this to your projectroot folder. 
+Upon installing the proguard-plugin, the rules will be added to your project.
+Example rules for various situations will be in the commented section in the plugin `proguard-custom.txt`.
 
 ```
 ionic cordova platform rm android

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,259 @@
+{
+  "name": "cordova-plugin-proguard",
+  "version": "2.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "jshint": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.0.tgz",
+      "integrity": "sha512-ooaD/hrBPhu35xXW4gn+o3SOuzht73gdBuffgJzrZBJZPGgGiiTvJEgTyxFvBO2nz0+X1G6etF8SzUODTlLY6Q==",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.11",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "bugs": {
     "url": "https://github.com/greybax/cordova-plugin-proguard/issues"
   },
-  "homepage": "https://github.com/greybax/cordova-plugin-proguard#readme"
+  "homepage": "https://github.com/greybax/cordova-plugin-proguard#readme",
+  "devDependencies": {
+    "jshint": "^2.11.0"
+  }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,9 @@
   <description>Activated ProGuard for Android</description>
 
   <platform name="android">
+    <preference name="HAS_BILLING" />
     <framework src="build.gradle" custom="true" type="gradleReference" />
     <asset src="proguard-custom.txt" target="proguard-custom.txt" />
+    <hook type="before_plugin_install" src="scripts/androidBeforeInstall.js" />
   </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,6 @@
   <description>Activated ProGuard for Android</description>
 
   <platform name="android">
-    <preference name="HAS_BILLING" />
     <framework src="build.gradle" custom="true" type="gradleReference" />
     <asset src="proguard-custom.txt" target="proguard-custom.txt" />
     <hook type="before_plugin_install" src="scripts/androidBeforeInstall.js" />

--- a/scripts/androidBeforeInstall.js
+++ b/scripts/androidBeforeInstall.js
@@ -1,0 +1,31 @@
+// adding options to proguard-custom file
+let fs = require('fs');
+let path = require('path');
+
+module.exports = function (ctx) {
+  let pluginDir = ctx.opts.plugin.dir;
+  let proguardFile = path.join(pluginDir, 'proguard-custom.txt');
+  let keepBillingContent = '-keep class com.android.vending.billing.** { *; }\n';
+  let searchArr = process.argv;//get cordova command line arguments
+  let getPreferenceValue = function (name) {
+    let found = searchArr.find(element => element.indexOf(name + '=') > -1);
+    if (!found) {
+      return false;
+    }
+    let val = found.split('=')[1];
+    if (val === 'true') {
+      return true;
+    }
+    return false;
+  };
+
+  let addToProguard = function (str) {
+    fs.appendFileSync(proguardFile, str);
+  };
+
+  let HAS_BILLING = getPreferenceValue('HAS_BILLING');
+  if (HAS_BILLING) {
+    addToProguard(keepBillingContent);
+  }
+  console.log('HAS_BILLING proguard set: ' + HAS_BILLING);
+};

--- a/scripts/androidBeforeInstall.js
+++ b/scripts/androidBeforeInstall.js
@@ -1,31 +1,22 @@
-// adding options to proguard-custom file
+// adding options from project-custom file in platformpath to default proguard-custom file in pluginpath
 let fs = require('fs');
 let path = require('path');
 
 module.exports = function (ctx) {
-  let pluginDir = ctx.opts.plugin.dir;
-  let proguardFile = path.join(pluginDir, 'proguard-custom.txt');
-  let keepBillingContent = '-keep class com.android.vending.billing.** { *; }\n';
-  let searchArr = process.argv;//get cordova command line arguments
-  let getPreferenceValue = function (name) {
-    let found = searchArr.find(element => element.indexOf(name + '=') > -1);
-    if (!found) {
-      return false;
+  const projectRoot = ctx.opts.projectRoot;
+  const pluginDir = ctx.opts.plugin.dir;
+  const targetProguardFile = path.join(pluginDir, 'proguard-custom.txt');
+  const projectProguardFile = path.join(projectRoot, 'proguard-custom.txt');
+  
+  try {
+    if (fs.existsSync(projectProguardFile)) {
+      const data = fs.readFileSync(projectProguardFile, 'utf8');
+      fs.appendFileSync(targetProguardFile, data);
+      console.log('Added optional proguard-rules to proguardFile.');
+    } else {
+      console.log('No optional proguard-custom.txt found in projectRoot: ' + projectRoot);
     }
-    let val = found.split('=')[1];
-    if (val === 'true') {
-      return true;
-    }
-    return false;
-  };
-
-  let addToProguard = function (str) {
-    fs.appendFileSync(proguardFile, str);
-  };
-
-  let HAS_BILLING = getPreferenceValue('HAS_BILLING');
-  if (HAS_BILLING) {
-    addToProguard(keepBillingContent);
+  } catch(err) {
+    console.error(err)
   }
-  console.log('HAS_BILLING proguard set: ' + HAS_BILLING);
 };

--- a/scripts/androidBeforeInstall.js
+++ b/scripts/androidBeforeInstall.js
@@ -7,7 +7,7 @@ module.exports = function (ctx) {
   const pluginDir = ctx.opts.plugin.dir;
   const targetProguardFile = path.join(pluginDir, 'proguard-custom.txt');
   const projectProguardFile = path.join(projectRoot, 'proguard-custom.txt');
-  
+
   try {
     if (fs.existsSync(projectProguardFile)) {
       const data = fs.readFileSync(projectProguardFile, 'utf8');
@@ -17,6 +17,6 @@ module.exports = function (ctx) {
       console.log('No optional proguard-custom.txt found in projectRoot: ' + projectRoot);
     }
   } catch(err) {
-    console.error(err)
+    console.error(err);
   }
 };

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -e
+set -o xtrace
+
+# Set variables: PLUGIN_DIR, TEST_DIR, BUILD_DIR
+cd "$(dirname "$0")/.."
+ROOT_DIR="$(pwd)"
+TEST_DIR="$ROOT_DIR/test"
+BUILD_DIR="${BUILD_DIR:-/tmp/build-$RANDOM}"
+
+# Create and enter the build directory
+rm -fr "$BUILD_DIR"
+cd "$TEST_DIR"
+
+# Command line parameters
+BUNDLE_ID="$1"
+IAP_ID="$2"
+
+#PLUGIN_URL="git://github.com/j3k0/PhoneGap-InAppPurchase-iOS.git#unified"
+PLUGIN_URL="$ROOT_DIR"
+
+if [ "x$IAP_ID" = "x" ] || [ "x$1" = "x--help" ]; then
+    echo
+    echo "usage: $0 <bundle_id> <iap_id>"
+    echo
+    echo "This will generate a cordova project using Cordova $TEST_VERSION (required)."
+    echo
+    echo "example:"
+    echo "    \$ $0 com.graybax.progplugintest progplugintest"
+    echo
+    exit 1
+fi
+
+# Add cordova to PATH
+export PATH="$ROOT_DIR/node_modules/.bin:$PATH"
+
+# Create a project
+cordova create "$BUILD_DIR" "$BUNDLE_ID" Test
+
+cd "$BUILD_DIR"
+
+echo Prepare platforms
+cordova platform add android || exit 1
+
+# copy dummy
+echo Copy customrules
+CUSTOM_RULES="$TEST_DIR/txt/proguard-custom.txt"
+cp "$CUSTOM_RULES" "$BUILD_DIR/"
+
+echo Add Proguard plugin
+cordova plugin add "$PLUGIN_URL" || exit 1
+
+# Add console debug
+# cordova plugin add https://github.com/apache/cordova-plugin-console.git || exit 1
+
+# Check existance of the plugins files
+function hasFile() {
+    if test -e "$1"; then
+       echo "File $1 installed."
+    else
+       echo "ERROR: File $1 is missing."
+       echo
+       echo " => it can be found at the following locations:"
+       find "$BUILD_DIR" -name "$(basename "$1")"
+       echo
+       EXIT=1
+    fi
+}
+
+# Compile for Android
+echo "Android build..."
+if ! cordova build android 2>&1 > $BUILD_DIR/build-android.txt; then
+    tail -500 $BUILD_DIR/build-android.txt
+    exit 1
+fi
+tail -20 $BUILD_DIR/build-android.txt
+
+echo "Check Android installation"
+
+# check Proguard custom file has been installed
+PROGUARD_CUSTOM_FILE="$BUILD_DIR/platforms/android/app/src/main/assets/www/proguard-custom.txt"
+if test ! -e "$PROGUARD_CUSTOM_FILE"; then
+  echo "ERROR: Proguard-custom file not found."
+  EXIT=1
+fi
+
+hasFile "$PROGUARD_CUSTOM_FILE"
+
+# nu nog een test of de twee customfiles zijn samengevoegd.
+EXTRA_RULES=$(<$CUSTOM_RULES)
+
+echo "Extra rules in proguard check"
+echo "$EXTRA_RULES"
+
+if grep "$EXTRA_RULES" "$PROGUARD_CUSTOM_FILE" > /dev/null; then
+  echo "CUSTOM RULES successfully added has been setup."
+else
+  echo "ERROR: SOMETHING WENT WRONG."
+  EXIT=1
+fi
+
+if [ "x$EXIT" != "x1" ]; then
+  echo "Great! Everything looks good.";
+fi
+
+exit $EXIT

--- a/test/run.sh
+++ b/test/run.sh
@@ -26,7 +26,7 @@ if [ "x$IAP_ID" = "x" ] || [ "x$1" = "x--help" ]; then
     echo "This will generate a cordova project using Cordova $TEST_VERSION (required)."
     echo
     echo "example:"
-    echo "    \$ $0 com.graybax.progplugintest progplugintest"
+    echo "    \$ $0 com.greybax.progplugintest progplugintest"
     echo
     exit 1
 fi
@@ -86,7 +86,7 @@ fi
 
 hasFile "$PROGUARD_CUSTOM_FILE"
 
-# nu nog een test of de twee customfiles zijn samengevoegd.
+# finally test if the extra rules are in place in the default proguard-custom.txt file
 EXTRA_RULES=$(<$CUSTOM_RULES)
 
 echo "Extra rules in proguard check"

--- a/test/txt/proguard-custom.txt
+++ b/test/txt/proguard-custom.txt
@@ -1,0 +1,1 @@
+# This is the rule file that goes into the root


### PR DESCRIPTION
adding billing proguard option through `cordova plugin add cordova-plugin-proguard --variable HAS_BILLING=true`

If you add 

`-keep class com.android.vending.billing.** { *; }`

Directly to proguard-custom.txt, anyone who is not using the billing class will get (unnecessary) warnings. I figured there should be a way to customize the proguard-custom.txt file without having to fork the repo.
So my proposal is to add a hook ‘androidBeforeInstall.js’ which adds the needed line based on the commandline.

`cordova plugin add cordova-plugin-proguard --variable HAS_BILLING=true` 

will add the billing line, and if set to false (or anything else) it will not.

It has a couple of drawbacks though:

1) If you remove the plugin, you should add the variable name again, otherwise cordova will complain
2) If you omit the HAS_BILLING, cordova will complain.

You can add other options by using more variables like so:

`cordova plugin add cordova-plugin-proguard --variable HAS_BILLING=true —-variable HAS_SOMETHING_ELSE=true` 

What do you think?
