### PR TITLE
Merge proguard-custom.txt at after prepare, don't overwrite plugin file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can read more about it on [ProGuard official website](https://www.guardsquar
 You can also to check out some [Android ProGuard snippets](https://github.com/krschultz/android-proguard-snippets)
 
 If you want to add rules to this `proguard-custom.txt`, please create your own `proguard-custom.txt` and add this to your projectroot folder. 
-Upon installing the proguard-plugin, the rules will be added to your project.
+Upon preparing the app, the rules will merged with the base file.
 Example rules for various situations will be in the commented section in the plugin `proguard-custom.txt`.
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-proguard",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Cordova plugin for ProGuard",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" id="cordova-plugin-proguard" version="2.2.0">
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" id="cordova-plugin-proguard" version="2.2.1">
   <name>Cordova plugin ProGuard</name>
   <description>Activated ProGuard for Android</description>
-
   <platform name="android">
     <framework src="build.gradle" custom="true" type="gradleReference" />
     <asset src="proguard-custom.txt" target="proguard-custom.txt" />
-    <hook type="before_plugin_install" src="scripts/androidBeforeInstall.js" />
+    <hook type="after_prepare" src="scripts/androidBeforeInstall.js" />
   </platform>
 </plugin>

--- a/scripts/androidBeforeInstall.js
+++ b/scripts/androidBeforeInstall.js
@@ -3,20 +3,19 @@ let fs = require('fs');
 let path = require('path');
 
 module.exports = function (ctx) {
-  const projectRoot = ctx.opts.projectRoot;
-  const pluginDir = ctx.opts.plugin.dir;
-  const targetProguardFile = path.join(pluginDir, 'proguard-custom.txt');
-  const projectProguardFile = path.join(projectRoot, 'proguard-custom.txt');
-
-  try {
-    if (fs.existsSync(projectProguardFile)) {
-      const data = fs.readFileSync(projectProguardFile, 'utf8');
-      fs.appendFileSync(targetProguardFile, data);
-      console.log('Added optional proguard-rules to proguardFile.');
-    } else {
-      console.log('No optional proguard-custom.txt found in projectRoot: ' + projectRoot);
-    }
-  } catch(err) {
-    console.error(err);
-  }
+    const projectRoot = ctx.opts.projectRoot;
+    const pluginDir = ctx.opts.plugin.dir;
+    const sourceProguardFile = path.join(pluginDir, 'proguard-custom.txt');
+    const projectProguardFile = path.join(projectRoot, 'proguard-custom.txt');
+    const destProguardFile = path.join(projectRoot, '/platforms/android/app/src/main/assets/www/proguard-custom.txt');
+    try {
+        let baseFile = fs.readFileSync(sourceProguardFile, 'utf8');
+        if (fs.existsSync(projectProguardFile)) {
+            const customFile = fs.readFileSync(projectProguardFile, 'utf8');
+            baseFile += '\r\n'+customFile;
+        }
+        fs.writeFileSync(destProguardFile, baseFile);
+    }catch(err) {
+        console.error(err);
+    }  
 };


### PR DESCRIPTION
Allows you to make changes to proguard-custom.txt in project file and have the final file up to date when running cordova prepare